### PR TITLE
hotfix/AddPageShareBoard_Explains_Logic

### DIFF
--- a/src/api/upload.js
+++ b/src/api/upload.js
@@ -15,3 +15,31 @@ export function uploadImage(image) {
 export function deleteUploadImage(fileKey) {
   return apiInstance.delete("/image-upload", fileKey)
 }
+
+export function uploadBase64Image(image) {
+  const data = new FormData()
+  data.append('image', image); // 'image'는 폼 필드 이름, 'image.png'는 파일 이름
+
+  return apiInstance.post("/image-upload",
+      data, {
+        headers: {
+          'content-type': 'multipart/form-data',
+        }
+      }
+  )
+}
+
+export function dataURLtoFile(dataurl, filename) {
+
+  var arr = dataurl.split(','),
+      mime = arr[0].match(/:(.*?);/)[1],
+      bstr = atob(arr[1]),
+      n = bstr.length,
+      u8arr = new Uint8Array(n);
+
+  while(n--){
+    u8arr[n] = bstr.charCodeAt(n);
+  }
+
+  return new File([u8arr], filename, {type:mime});
+}


### PR DESCRIPTION
### AddPageShareBoard
- Explains에 사진을 첨부할 때 만약 사진을 첨부 후 삭제를 한다면 사진은 이미 업로드가 됐기 때문에 자원 낭비가 심할 것을 예상하여 로직 변경
  - 사진 첨부 시에 업로드 -> 게시물 작성 시 일괄 업로드

### 트러블 슈팅
- 일괄 업로드 후 img의 src를 바꾸는 중 postContent의 img 태그의 src는 바뀌었으나 innerHTML은 수정되지 않아 업로드된 이미지의 url이 아니라 base64로 된 이미지로 요청되는 문제 발생
  - 해당 문제는 동기화 문제로 확인되어 Promise로 upload 로직이 전부 완료된 후 게시물 작성 요청이 가도록 수정
  - 동기화 문제 확인 방법
    - contentTarget을 확인했을 때 contentTarget 자체는 src가 업로드 url로 수정되었으나 innerHTML을 보면 수정되지 않은 것을 확인